### PR TITLE
Support an arbitrary number of configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^tests/test_files'
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
             -   id: fix-encoding-pragma
             -   id: trailing-whitespace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
+dist: xenial
 python:
-- 3.6
+- 3.7
 services:
 - redis-server
 stages:
@@ -13,7 +14,7 @@ env:
 jobs:
   include:
   - stage: lint
-    python: 3.6
+    python: 3.7
     script: pre-commit run -a
   - stage: test
     script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ pull_requests:
 environment:
   BROKER_URL: redis://localhost:6379/0
   matrix:
-    - PYTHON: C:\Python36-x64
+    - PYTHON: C:\Python37-x64
 
 install:
   - ps: >

--- a/pacifica/dispatcher_proxymod/jsonpath2/proxymod.txt
+++ b/pacifica/dispatcher_proxymod/jsonpath2/proxymod.txt
@@ -18,6 +18,14 @@ $[?(
   $["data"][*][?(
     @["destinationTable"] = "TransactionKeyValue"
       and
+    @["key"] = "proxymod.configs_count"
+      and
+    @["value"]
+  )]
+    and
+  $["data"][*][?(
+    @["destinationTable"] = "TransactionKeyValue"
+      and
     @["key"] = "proxymod.config_1.PROJECT.runtime"
       and
     @["value"]
@@ -59,54 +67,6 @@ $[?(
     @["destinationTable"] = "TransactionKeyValue"
       and
     @["key"] = "proxymod.config_1.OUTPUTS.out_dir"
-      and
-    @["value"]
-  )]
-    and
-  $["data"][*][?(
-    @["destinationTable"] = "TransactionKeyValue"
-      and
-    @["key"] = "proxymod.config_2.PROJECT.runtime"
-      and
-    @["value"]
-  )]
-    and
-  $["data"][*][?(
-    @["destinationTable"] = "TransactionKeyValue"
-      and
-    @["key"] = "proxymod.config_2.PROJECT.failure"
-      and
-    @["value"]
-  )]
-    and
-  $["data"][*][?(
-    @["destinationTable"] = "TransactionKeyValue"
-      and
-    @["key"] = "proxymod.config_2.OUTPUTS.out_dir"
-      and
-    @["value"]
-  )]
-    and
-  $["data"][*][?(
-    @["destinationTable"] = "TransactionKeyValue"
-      and
-    @["key"] = "proxymod.config_3.PROJECT.runtime"
-      and
-    @["value"]
-  )]
-    and
-  $["data"][*][?(
-    @["destinationTable"] = "TransactionKeyValue"
-      and
-    @["key"] = "proxymod.config_3.PROJECT.failure"
-      and
-    @["value"]
-  )]
-    and
-  $["data"][*][?(
-    @["destinationTable"] = "TransactionKeyValue"
-      and
-    @["key"] = "proxymod.config_3.OUTPUTS.out_dir"
       and
     @["value"]
   )]

--- a/tests/test_files/C234-1234-1234/event.json
+++ b/tests/test_files/C234-1234-1234/event.json
@@ -30,6 +30,11 @@
     },
     {
       "destinationTable": "TransactionKeyValue",
+      "key": "proxymod.configs_count",
+      "value": "3"
+    },
+    {
+      "destinationTable": "TransactionKeyValue",
       "key": "proxymod.config_1.PROJECT.runtime",
       "value": "2"
     },


### PR DESCRIPTION
### Description

Adds support for an arbitrary number of configurations, specified via the new `proxymod.configs_count` transaction key-value pair.

### Issues Resolved

Fixes #2 

### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
